### PR TITLE
feat(avahi): Enable IPv6 as well as IPv4

### DIFF
--- a/data/etc/avahi/services/revpipyload.service
+++ b/data/etc/avahi/services/revpipyload.service
@@ -2,7 +2,7 @@
 <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
 <service-group>
     <name replace-wildcards="yes">%h</name>
-    <service protocol="ipv4">
+    <service protocol="any">
         <type>_revpipyload._tcp</type>
         <port>55123</port>
     </service>


### PR DESCRIPTION
We live in the year 2023 and therefore should annouce services over IPv6 too :-)